### PR TITLE
Improve afterparty page styling

### DIFF
--- a/afterparty/index.html
+++ b/afterparty/index.html
@@ -1,0 +1,224 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>After Party RSVP - Patty and Robbie</title>
+  <style>
+    /* Galano Grotesque for headers and subheads */
+    @font-face {
+      font-family: 'GalanoGrotesque';
+      src: url('../fonts/GalanoGrotesqueDEMO-Bold.otf') format('opentype');
+      font-weight: 900;
+      font-style: normal;
+    }
+    /* HK Requisite for body copy */
+    @font-face {
+      font-family: 'HKRequisite';
+      src: url('../fonts/HKRequisite-Medium.otf') format('opentype');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    a {
+    color: #333333; /* Sets all links to body color */
+    }
+
+    :root {
+      --accent-color: #a67c52;
+      --bg-color: #f5f0e0;
+      --text-color: #333333;
+      --body-font: 'HKRequisite', sans-serif;
+      --title-font: 'GalanoGrotesque', sans-serif;
+      --header-scale: 1.15;
+      --hover-color: olive;
+      --scroll-threshold: 100px;
+    }
+
+    *, *::before, *::after { box-sizing: border-box; }
+    body {
+      margin: 0;
+      padding: 13rem 2rem 4rem; /* keep content below the fixed header and above the footer */
+      font-family: var(--body-font);
+      background-color: var(--bg-color);
+      color: var(--text-color);
+      line-height: 1.6;
+      text-align: center;
+    }
+    header {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      background: var(--bg-color);
+      padding: 4rem 2rem 1rem;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      transition: all 0.3s ease;
+      z-index: 1000;
+    }
+    header.scrolled {
+      padding: 0.5rem 2rem;
+      flex-direction: row;
+      justify-content: space-between;
+    }
+    h1 {
+      font-family: var(--title-font);
+      font-weight: 900;
+      text-transform: uppercase;
+      font-size: 6rem;
+      line-height: 0.9;
+      margin: 0 0 0.5rem;
+      padding: 0 1rem; /* prevent text from touching edges */
+      display: inline-block;
+      transform: scaleX(var(--header-scale));
+      transform-origin: center;
+      transition: all 0.3s ease;
+    }
+    /* Remove breaks when scrolled */
+    header.scrolled h1 {
+      font-size: 2rem;
+      transform: scaleX(1);
+      white-space: nowrap;
+      margin: 0;
+    }
+    header.scrolled h1 br { display: none; }
+    .subheading {
+      font-family: var(--title-font);
+      color: var(--accent-color);
+      font-size: 1.125rem;
+      margin: 0 0 1rem;
+      display: block;
+      transition: opacity 0.3s;
+    }
+    header.scrolled .subheading { display: none; }
+    .btn {
+      display: inline-block;
+      padding: 0.75rem 1.5rem;
+      background: var(--accent-color);
+      color: #ffffff;
+      border: none;
+      border-radius: 5px;
+      text-decoration: none;
+      font-family: var(--title-font);
+      font-weight: 900;
+      margin-top: 0.5rem;
+      font-size: 1.125rem;
+      transition: background 0.3s;
+    }
+    .btn:hover {
+      background: var(--hover-color);
+      color: #ffffff;
+    }
+    input[type="text"],
+    input[type="email"],
+    select,
+    textarea {
+      font-family: var(--body-font);
+      font-size: 1rem;
+      padding: 0.5rem 0.25rem;
+      background: transparent;
+      border: none;
+      border-bottom: 4px solid #000;
+      border-radius: 0;
+      max-width: 300px;
+      width: 100%;
+      display: block;
+      margin: 0 auto;
+    }
+    select {
+      color: var(--text-color);
+      text-align: center;
+      text-align-last: center;
+      background: transparent;
+    }
+    form p { text-align: center; }
+    .section-title {
+      font-family: var(--title-font);
+      font-size: 2rem;
+      color: var(--accent-color);
+      margin-bottom: 1rem;
+    }
+    section, footer { padding-top: 2rem; }
+    footer {
+      position: fixed;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      background: var(--bg-color);
+      padding: 1rem 0;
+    }
+    body { cursor: none; }
+    .mobile-break { display: none; }
+    #custom-cursor {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 20px;
+      height: 20px;
+      border-radius: 50%;
+      background: var(--hover-color);
+      pointer-events: none;
+      transform: translate(-50%, -50%);
+      z-index: 10000;
+    }
+    #our-story { display: none; }
+    @media (max-width: 600px) {
+      h1 { font-size: 3.5rem; transform: scaleX(1); }
+      .mobile-break { display: inline; }
+      /* Keep mobile smaller but still enough viewport */
+    }
+  </style>
+</head>
+<body>
+  <div id="custom-cursor"></div>
+  <header>
+    <h1>After<br class="mobile-break">Party<br class="mobile-break">RSVP</h1>
+    <p class="subheading">Let us know if you're coming!</p>
+  </header>
+
+  <section id="rsvp">
+    <form action="https://formspree.io/f/mnnzvevz" method="POST">
+      <p>
+        <label for="name">Name</label><br>
+        <input type="text" id="name" name="name" required>
+      </p>
+      <p>
+        <label for="email">Email</label><br>
+        <input type="email" id="email" name="email" required>
+      </p>
+      <p>
+        <label for="attending">Will you attend?</label><br>
+        <select id="attending" name="attending" required>
+          <option value="Yes">Yes</option>
+          <option value="No">No</option>
+        </select>
+      </p>
+      <p>
+        <label for="notes">Notes</label><br>
+        <textarea id="notes" name="notes" rows="4" cols="40"></textarea>
+      </p>
+      <button type="submit" class="btn">Send RSVP</button>
+    </form>
+  </section>
+
+  <footer>
+    <p>&copy; 2025 Patty &amp; Robbie</p>
+  </footer>
+
+  <script>
+    const header = document.querySelector('header');
+    window.addEventListener('scroll', () => {
+      const offset = window.pageYOffset;
+      if (offset > 100) header.classList.add('scrolled');
+      else header.classList.remove('scrolled');
+    });
+    const cursor = document.getElementById('custom-cursor');
+    window.addEventListener('mousemove', (e) => {
+      cursor.style.left = `${e.clientX}px`;
+      cursor.style.top = `${e.clientY}px`;
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- prevent header text from touching the sides
- keep custom cursor olive by removing blend mode
- restyle form inputs with a black underline
- stack the RSVP heading words on small screens for larger type

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68819b7b57d8832cbc1df5cab0610825